### PR TITLE
Fixes TypeError when trying to operate on empty cell

### DIFF
--- a/CommcareTranslationChecker/CommcareTranslationChecker.py
+++ b/CommcareTranslationChecker/CommcareTranslationChecker.py
@@ -161,7 +161,7 @@ def main(argv):
             if args.columns:
                 if cell.value in args.columns:
                     defaultColumnDict[headerIdx] = cell.value
-            elif cell.value[:8] == "default_":
+            elif cell.value and cell.value[:8] == "default_":
                 defaultColumnDict[headerIdx] = cell.value
             if headerIdx > maxHeaderIdx:
                 maxHeaderIdx = headerIdx


### PR DESCRIPTION
This script was crashing today for Lilliana when trying to run this for some transalations excel with following error - 

```
  File "CommcareTranslationChecker.py", line 224, in <module>
    entryPoint()
  File "CommcareTranslationChecker.py", line 221, in entryPoint
    main(sys.argv[1:])
  File "CommcareTranslationChecker.py", line 165, in main
    elif cell.value[:8] == "default_":
TypeError: 'NoneType' object has no attribute '__getitem__'
```

This was happening for entirely empty excel columns present after the translations column. I have added a simple null check to get past this but there might be some faulty pre condition which I am not aware of that should not have allowed script to operate on empty columns at all. Feel free to close if that's the case. 