### PR TITLE
Mismatch Descriptions and Descriptive Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CommcareTranslationChecker/LALAOUTPUT/
 commcareTranslationChecker_Output
 *.xlsx
 *.zip
+examples/*.txt

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.9.2',
+    version='0.9.2.1',
 
     description='Command line tool to check that Bulk Translation files for CommCare apps have consistent <output value.../> tags across translations.',
     long_description=long_description,


### PR DESCRIPTION
Added the ability to determine the exact types of mismatch that occur, and to output those mismatches to the end user. Also added somewhat more descriptive errors.

Now mismatch types can be appended to the end of the output worksheet and/or added to the command line output. This is turned on by the new argument:
--output-mismatch-types